### PR TITLE
add option to distribute poap to all users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. Connect Wallet with `/connect` command.
 2. Read currently connected wallet with `/wallet` command.
+3. Add option to distribute poap to all users
 
 ## 2.8.0
 

--- a/src/app/commands/poap/POAP.ts
+++ b/src/app/commands/poap/POAP.ts
@@ -184,6 +184,12 @@ export default class POAP extends SlashCommand {
 								},
 							],
 						},
+						{
+							name: 'all-users',
+							type: CommandOptionType.BOOLEAN,
+							description: 'Send POAP to all users in this Discord server',
+							required: false,
+						},
 					],
 				},
 				{
@@ -262,7 +268,7 @@ export default class POAP extends SlashCommand {
 			case 'distribute':
 				platform = ctx.options.distribute['platform'] != null && ctx.options.distribute['platform'] != '' ? ctx.options.distribute['platform'] : constants.PLATFORM_TYPE_DISCORD;
 				Log.debug(`platform: ${platform}`);
-				commandPromise = DistributePOAP(ctx, guildMember as GuildMember, ctx.options.distribute['event'], platform);
+				commandPromise = DistributePOAP(ctx, guildMember as GuildMember, ctx.options.distribute['event'], platform, ctx.options.distribute['all-users']);
 				break;
 			case 'claim':
 				platform = ctx.options.claim.platform != null && ctx.options.claim.platform != '' ? ctx.options.claim.platform : constants.PLATFORM_TYPE_DISCORD;

--- a/src/app/service/poap/DistributePOAP.ts
+++ b/src/app/service/poap/DistributePOAP.ts
@@ -17,7 +17,7 @@ import MongoDbUtils from '../../utils/MongoDbUtils';
 import ServiceUtils from '../../utils/ServiceUtils';
 import { POAPDistributionResults } from '../../types/poap/POAPDistributionResults';
 
-export default async (ctx: CommandContext, guildMember: GuildMember, event: string, platform: string): Promise<any> => {
+export default async (ctx: CommandContext, guildMember: GuildMember, event: string, platform: string, allUsers: boolean): Promise<any> => {
 	if (ctx.guildID == undefined) {
 		await ctx.send('Please try poap distribution within discord channel');
 		return;
@@ -31,7 +31,12 @@ export default async (ctx: CommandContext, guildMember: GuildMember, event: stri
 	await ctx.defer(true);
 	await ctx.send({ content: '⚠ Please make sure this is a private channel. I can help you distribute POAPs but anyone who has access to this channel can see private information! ⚠', ephemeral: true });
 	
-	let participantsList: POAPFileParticipant[] | TwitterPOAPFileParticipant[] = await askForParticipantsList(guildMember, platform, ctx);
+	let participantsList: POAPFileParticipant[] | TwitterPOAPFileParticipant[];
+	if (allUsers) {
+		participantsList = await ServiceUtils.getAllMembersAsPOAPFilePartcipant(guildMember.guild);
+	} else {
+		participantsList = await askForParticipantsList(guildMember, platform, ctx);
+	}
 	const numberOfParticipants: number = participantsList.length;
 	
 	if (numberOfParticipants <= 0) {

--- a/src/app/utils/ServiceUtils.ts
+++ b/src/app/utils/ServiceUtils.ts
@@ -64,6 +64,16 @@ const ServiceUtils = {
 		});
 	},
 
+	async getAllMembersAsPOAPFilePartcipant(guild: Guild): Promise<POAPFileParticipant[]> {
+		const guildMembers = await guild.members.fetch();
+		return guildMembers.filter(member => !member.user.bot).map(member => {
+			return {
+				discordUserId: member.id,
+				discordUserTag: member.user.tag,
+			} as POAPFileParticipant;
+		});
+	},
+
 	hasRole(guildMember: GuildMember, role: string): boolean {
 		return guildMember.roles.cache.some(r => r.id === role);
 	},


### PR DESCRIPTION
This feature adds a sub-command to `/poap distribute` called `all-users`. If set to true, the bot will not ask for a lit of participants, and instead build a participants list consisting of all Discord server users. 

![Screen Shot 2022-03-14 at 5 00 55 PM](https://user-images.githubusercontent.com/42751791/158268482-219aee0e-2362-4aea-9637-dd1046d643df.png)

